### PR TITLE
[CD] 게시글 등록 이미지 최대사이즈 설정

### DIFF
--- a/src/components/createPost/CreatePostImageCrop.jsx
+++ b/src/components/createPost/CreatePostImageCrop.jsx
@@ -260,6 +260,7 @@ const CreatePostImageCrop = ({
             onChange={(crop) => setCrop(crop)}
             onComplete={(crop) => setCompletedCrop(crop)}
             aspect={aspect}
+            maxWidth="1080"
           >
             <img
               className="originImage"


### PR DESCRIPTION
- 아이폰 이미지 등록 안되는 현상 발생
- 이유를 찾아보니 이미지 4mb 이상 되는 사이즈면 캔버스를 사용할 수 없음(아이폰 메모리 제한)
- 최대사이즈 조절 필요하게 되어 설정함